### PR TITLE
Change to results parsing function - ignore regional settings

### DIFF
--- a/SlackerRunner/ResultsParser.cs
+++ b/SlackerRunner/ResultsParser.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SlackerRunner.Poco;
+using System.Globalization;
 
 namespace SlackerRunner
 {
@@ -188,7 +189,8 @@ namespace SlackerRunner
     private static double FindDouble(string group, string result, Regex regex)
     {
       string match = regex.Match(result).Groups[group].Value;
-      return string.IsNullOrEmpty(match) ? 0 : double.Parse(match);
+      // Make parsing from type Double insensitive to localization settings
+      return string.IsNullOrEmpty(match) ? 0 : double.Parse(match, CultureInfo.InvariantCulture);
     }
 
     private static Example InitExample()


### PR DESCRIPTION
PR to fix regional settings issues experienced with #22  . The results parsing failed when attempting to parse the "elapsed seconds" string values to double as a results of local regional settings. Subsequently presents failures in processing results back to Visual Studio Test Explorer.

The tests run successfully but the problem comes in when SlackerRunner.ResultsParser is trying to convert certain string (seconds) values from string to double here:
image

Attempts to reproduce the issue was difficult as regional settings might be different to mine.

So I made a minor change to the double.parse code to make it culture insensitive here:
![image](https://user-images.githubusercontent.com/25621492/47378672-24f46f80-d6f9-11e8-964b-72c63db278f5.png)

